### PR TITLE
Changed version to 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxweb-scb-style",
-  "version": "0.9",
+  "version": "0.9.0",
   "description": "SCB:s alternative PxWeb styling for the statistical database",
   "main": "index.html",
   "scripts": {


### PR DESCRIPTION
It was not possible to build when version number was 0.9. Changed to 0.9.0.